### PR TITLE
Add option to CheckCoverage comamnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ List of available commands:
     * `--ignored-paths [values]` - accepts path patterns that should be ignored,
         delimited by coma.
 * **CheckCoverage** — checks coverage by executing `SimpleCov::collate`.
-    You should set `SimpleCov::minimum_coverage` in your `spec_helper.rb` file.
-    Accepted flags: `--split-resultset`.
+    Accepted flags: `--split-resultset`, `--setup-file-path`.
     * `--split-resultset` — if you execute command `RunSpecs` with `--split-resultset true`,
         you also should set this flag to `true`. If this flag set to `true`, final coverage will be
         calculated by merging results in all files, matching the mask `coverage/resultset.*.json`.
         By default final coverage is calculated using result from `coverage/.resultset.json`.
+    * `--setup-file-path` — relative path to your `.rb` file, which setups `SimpleCov`.
+      Usually it is `spec_helper.rb`.
 
 ### Rake Tasks
 

--- a/lib/ci_helper/commands/check_coverage.rb
+++ b/lib/ci_helper/commands/check_coverage.rb
@@ -6,7 +6,7 @@ module CIHelper
   module Commands
     class CheckCoverage < BaseCommand
       def call
-        require_relative setup_file_path unless setup_file_path.nil?
+        require_relative(setup_file_path) unless setup_file_path.nil?
 
         ::SimpleCov.collate(files)
         0

--- a/lib/ci_helper/commands/check_coverage.rb
+++ b/lib/ci_helper/commands/check_coverage.rb
@@ -6,7 +6,7 @@ module CIHelper
   module Commands
     class CheckCoverage < BaseCommand
       def call
-        require_relative(setup_file_path) unless setup_file_path.nil?
+        require(path.join(setup_file_path)) unless setup_file_path.nil?
 
         ::SimpleCov.collate(files)
         0

--- a/lib/ci_helper/commands/check_coverage.rb
+++ b/lib/ci_helper/commands/check_coverage.rb
@@ -6,6 +6,8 @@ module CIHelper
   module Commands
     class CheckCoverage < BaseCommand
       def call
+        require_relative setup_file_path unless setup_file_path.nil?
+
         ::SimpleCov.collate(files)
         0
       end
@@ -20,6 +22,10 @@ module CIHelper
 
       def split_resultset?
         options[:split_resultset] == "true"
+      end
+
+      def setup_file_path
+        options[:setup_file_path]
       end
     end
   end

--- a/lib/ci_helper/version.rb
+++ b/lib/ci_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CIHelper
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/spec/ci_helper/commands/check_coverage_spec.rb
+++ b/spec/ci_helper/commands/check_coverage_spec.rb
@@ -46,7 +46,7 @@ describe CIHelper::Commands::CheckCoverage do
     let(:options) { Hash[setup_file_path: "relative/path/to/spec_helper"] }
 
     it "requires this file" do
-      expect(instance).to receive(:require_relative).with("relative/path/to/spec_helper")
+      expect(instance).to receive(:require).with(pathname_for_join)
       expect(command).to eq(0)
       expect(collate_args.size).to eq(1)
       expect(collate_args.first).to be_an_instance_of(Array)
@@ -61,7 +61,7 @@ describe CIHelper::Commands::CheckCoverage do
     let(:options) { Hash[] }
 
     it "doesn't require file" do
-      expect(instance).not_to receive(:require_relative)
+      expect(instance).not_to receive(:require)
       expect(command).to eq(0)
     end
   end

--- a/spec/ci_helper/commands/check_coverage_spec.rb
+++ b/spec/ci_helper/commands/check_coverage_spec.rb
@@ -38,4 +38,31 @@ describe CIHelper::Commands::CheckCoverage do
       expect(collate_args.first.first).to eq(pathname_for_join)
     end
   end
+
+  context "when setup file flag is passed" do
+    subject(:command) { instance.call }
+
+    let(:instance) { described_class.new(**options) }
+    let(:options) { Hash[setup_file_path: "relative/path/to/spec_helper"] }
+
+    it "requires this file" do
+      expect(instance).to receive(:require_relative).with("relative/path/to/spec_helper")
+      expect(command).to eq(0)
+      expect(collate_args.size).to eq(1)
+      expect(collate_args.first).to be_an_instance_of(Array)
+      expect(collate_args.first.first).to eq(pathname_for_join)
+    end
+  end
+
+  context "when setup file flag isn't passed" do
+    subject(:command) { instance.call }
+
+    let(:instance) { described_class.new(**options) }
+    let(:options) { Hash[] }
+
+    it "doesn't require file" do
+      expect(instance).not_to receive(:require_relative)
+      expect(command).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Add new option to CheckCoverage command: `--setup-file-path`, with which you can require your `setup.rb` for SimpleCov