### PR TITLE
Heavy specs distribution for RunSpecs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-helper (0.7.0)
+    ci-helper (0.8.0)
       colorize (~> 1.1)
       dry-inflector (~> 1.0)
       umbrellio-sequel-plugins (~> 0.14)

--- a/lib/ci_helper/commands/run_specs.rb
+++ b/lib/ci_helper/commands/run_specs.rb
@@ -4,11 +4,12 @@ module CIHelper
   module Commands
     class RunSpecs < BaseCommand
       def call
-        return if job_files.empty?
+        files_to_run = job_files
+        return if files_to_run.empty?
 
         create_and_migrate_database! if with_database?
         create_and_migrate_clickhouse_database! if with_clickhouse?
-        execute("bundle exec rspec #{Shellwords.join(job_files)}")
+        execute("bundle exec rspec #{Shellwords.join(files_to_run)}")
         return 0 unless split_resultset?
 
         execute("mv coverage/.resultset.json coverage/resultset.#{job_index}.json")
@@ -22,11 +23,33 @@ module CIHelper
 
       def job_files
         all_files = path.glob("spec/**/*_spec.rb")
+
+        heavy_files = []
+        std_files   = []
+
+        all_files.each do |file|
+          relative_path = file.relative_path_from(path).to_s
+          if heavy_specs_paths.any? { |pattern| File.fnmatch?(pattern, relative_path) }
+            heavy_files << file
+          else
+            std_files << file
+          end
+        end
+
         sorted_files =
-          all_files.map { |x| [x.size, x.relative_path_from(path).to_s] }.sort.map(&:last)
-        sorted_files.reverse.select.with_index do |_file, index|
+          std_files.map { |x| [x.size, x.relative_path_from(path).to_s] }.sort.map(&:last)
+        (sorted_files + heavy_files).reverse.select.with_index do |_file, index|
           (index % job_count) == (job_index - 1)
         end
+      end
+
+      def heavy_specs_paths
+        @heavy_specs_paths ||=
+          begin
+            File.readlines("spec/heavy_specs.yml", chomp: true)
+          rescue
+            []
+          end
       end
 
       def job_index

--- a/lib/ci_helper/version.rb
+++ b/lib/ci_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CIHelper
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
Support for heavy_specs.yml where you can include long running spec files to be distributed evenly between CI job runners, thus speeding up total CI runtime.

heavy_specs.yml format is a simple list of file paths:
```
spec/requests/admin/**/*
spec/requests/reports/*
spec/services/index_spec.rb
```

