### PR TITLE
Add autorelease workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          version=$(grep -oP '(?<=VERSION = ")[^"]+' lib/ci_helper/version.rb)
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ruby/setup-ruby@v1
+        if: steps.check.outputs.exists == 'false'
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Build gem
+        if: steps.check.outputs.exists == 'false'
+        run: gem build ci_helper.gemspec
+
+      - name: Push gem to RubyGems
+        if: steps.check.outputs.exists == 'false'
+        run: gem push *.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+
+      - uses: softprops/action-gh-release@v3
+        if: steps.check.outputs.exists == 'false'
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          files: "*.gem"
+          generate_release_notes: true


### PR DESCRIPTION
Adds `.github/workflows/release.yml` to automate gem releases.

On every push to `master` the workflow:

1. Extracts the version from `lib/ci_helper/version.rb` → tag `vX.Y.Z`.
2. Skips the rest if a GitHub release for that tag already exists, so it only fires when the version is bumped (idempotent).
3. Builds the gem from `ci_helper.gemspec` (Ruby 3.4).
4. Pushes it to RubyGems using the `GEM_HOST_API_KEY` secret.
5. Creates a GitHub release for the tag with the built `.gem` attached and auto-generated release notes.

Modeled on the helmsnap release workflow, minus the Docker image steps since this gem ships no Dockerfile.

### Required setup
- A `GEM_HOST_API_KEY` repository secret containing a RubyGems API token with push access to the `ci-helper` gem.