### PR TITLE
Show the rspec command output when the dry-run fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-helper (0.10.1)
+    ci-helper (0.10.2)
       colorize (~> 1.1)
       dry-inflector (~> 1.0)
       umbrellio-sequel-plugins (~> 0.14)

--- a/lib/ci_helper/commands.rb
+++ b/lib/ci_helper/commands.rb
@@ -2,7 +2,14 @@
 
 module CIHelper
   module Commands
-    class Error < StandardError; end
+    class Error < StandardError
+      attr_reader :output
+
+      def initialize(message, output: nil)
+        super(message)
+        @output = output
+      end
+    end
 
     class BaseCommand
       class << self
@@ -26,16 +33,19 @@ module CIHelper
         execute(*commands)
       end
 
-      def execute(*commands)
+      def execute(*commands, capture: false)
         command = commands.join(" && ")
 
         process_stdout.puts(Tools::Colorize.command(command))
 
+        captured = +"" if capture
         Open3.popen2e(command) do |_stdin, stdout, thread|
-          stdout.each_char { |char| process_stdout.print(char) }
+          stdout.each_char { |char| capture ? captured << char : process_stdout.print(char) }
           exit_code = thread.value.exitstatus
 
-          fail!("Bad exit code #{exit_code} for command #{command.inspect}") unless exit_code.zero?
+          unless exit_code.zero?
+            fail!("Bad exit code #{exit_code} for command #{command.inspect}", output: captured)
+          end
           0
         end
       end
@@ -54,8 +64,8 @@ module CIHelper
         execute_with_env("bundle exec rake ch:create ch:migrate")
       end
 
-      def fail!(message)
-        raise Error, message
+      def fail!(message, output: nil)
+        raise Error.new(message, output: output)
       end
 
       def boolean_option?(key)

--- a/lib/ci_helper/commands/run_specs.rb
+++ b/lib/ci_helper/commands/run_specs.rb
@@ -50,10 +50,10 @@ module CIHelper
           begin
             execute(
               "bundle exec rspec --dry-run --format=json --out #{Shellwords.escape(output_file)}",
+              capture: true,
             )
-          rescue Error
-            output = File.exist?(output_file) ? File.read(output_file) : "(no output file)"
-            fail!("RSpec dry-run failed. Output file contents:\n#{output}")
+          rescue Error => error
+            fail!("RSpec dry-run failed:\n#{error.output}")
           end
           JSON.parse(File.read(output_file)).fetch("examples").map { |e| e.fetch("id") }
         end

--- a/lib/ci_helper/version.rb
+++ b/lib/ci_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CIHelper
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/spec/ci_helper/commands/run_specs_spec.rb
+++ b/spec/ci_helper/commands/run_specs_spec.rb
@@ -116,47 +116,28 @@ describe CIHelper::Commands::RunSpecs do
     end
 
     context "when dry-run exits with non-zero code" do
+      let(:rspec_error_output) do
+        "An error occurred while loading ./spec/broken_spec.rb.\n" \
+          "LoadError: cannot load such file -- some_gem"
+      end
+
       before do
         allow(Open3).to receive(:popen2e) do |cmd, &block|
           popen_executed_commands << cmd
-          thread = if cmd.include?("--dry-run")
-                     instance_double(Thread, value: instance_double(Process::Status, exitstatus: 1))
-                   else
-                     popen_thread
-                   end
-          block.call(StringIO.new, StringIO.new, thread)
+          if cmd.include?("--dry-run")
+            thread = instance_double(Thread, value: instance_double(Process::Status, exitstatus: 1))
+            block.call(StringIO.new, StringIO.new(rspec_error_output), thread)
+          else
+            block.call(StringIO.new, StringIO.new("kek"), popen_thread)
+          end
         end
       end
 
-      context "when output file exists" do
-        let(:error_output) { '{"messages":["LoadError: cannot load such file -- some_gem"]}' }
-
-        before do
-          allow(File).to receive(:exist?)
-            .with("/tmp/ci_helper_test/rspec_examples.json").and_return(true)
-          allow(File).to receive(:read)
-            .with("/tmp/ci_helper_test/rspec_examples.json").and_return(error_output)
-        end
-
-        it "raises error with output file contents" do
-          expect { command }.to raise_error(
-            CIHelper::Commands::Error,
-            /RSpec dry-run failed\..*#{Regexp.escape(error_output)}/m,
-          )
-        end
-      end
-
-      context "when output file is missing" do
-        before do
-          allow(File).to receive(:exist?)
-            .with("/tmp/ci_helper_test/rspec_examples.json").and_return(false)
-        end
-
-        it "raises error noting missing file" do
-          expect { command }.to raise_error(
-            CIHelper::Commands::Error,
-            /RSpec dry-run failed\..*\(no output file\)/m,
-          )
+      it "fails with the rspec command output rather than the json file" do
+        expect { command }.to raise_error(CIHelper::Commands::Error) do |error|
+          expect(error.message).to include("RSpec dry-run failed:")
+          expect(error.message).to include(rspec_error_output)
+          expect(error.message).not_to include("Output file contents")
         end
       end
     end


### PR DESCRIPTION
## Problem

`RunSpecs#example_ids` runs `rspec --dry-run --format=json --out <file>` to enumerate examples for splitting. On failure it printed the contents of that `--out` JSON file — i.e. the example list — as the error:

```
RSpec dry-run failed. Output file contents:
{"version":"3.13.6","examples":[ ...thousands of lines... ]}
```

That's never the error. The real failure (a load error, or an exception raised at `at_exit`) goes to the process's **stderr**. `execute` streamed it via `popen2e` but never captured it, so the rescue had only the JSON file to fall back on. Worse, when the crash happens at `at_exit` — after rspec has already written a complete JSON file — that file contains no trace of the error at all, so the log is just a giant, useless JSON blob.

## Fix

- `execute` takes an opt-in `capture:` flag. When set, it accumulates the command's combined stdout+stderr and attaches it to the raised `Error` (new `Error#output`). Default is `false`, so the streaming behaviour of every other call is unchanged (and large test runs aren't buffered into memory).
- `RunSpecs` runs the dry-run with `capture: true` and, on failure, fails with the captured output instead of the JSON file.

A failed dry-run now surfaces the actual error:

```
RSpec dry-run failed:
An error occurred while loading ./spec/broken_spec.rb.
LoadError: cannot load such file -- some_gem
```

Specs updated for the new behaviour; full suite is green with 100% line and branch coverage.
