### PR TITLE
Update RuboCop configuration, remove unused gem, and refactor some code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,12 @@ inherit_gem:
 
 AllCops:
   DisplayCopNames: true
+  NewCops: enable
   TargetRubyVersion: 3.2
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  EnforcedShorthandSyntax: always
 
 Naming/MethodParameterName:
   AllowedNames: ["x", "y", "z"]

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 gem "benchmark"
 gem "bundler"
 gem "bundler-audit"
-gem "ostruct"
 gem "pry"
 gem "rake"
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,6 @@ GEM
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
-    ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -153,7 +152,6 @@ DEPENDENCIES
   bundler
   bundler-audit
   ci-helper!
-  ostruct
   pry
   rake
   rspec

--- a/lib/ci_helper/commands.rb
+++ b/lib/ci_helper/commands.rb
@@ -65,7 +65,7 @@ module CIHelper
       end
 
       def fail!(message, output: nil)
-        raise Error.new(message, output: output)
+        raise Error.new(message, output:)
       end
 
       def boolean_option?(key)

--- a/lib/ci_helper/commands/check_sidekiq_scheduler_config.rb
+++ b/lib/ci_helper/commands/check_sidekiq_scheduler_config.rb
@@ -29,7 +29,7 @@ module CIHelper
       end
 
       def job_constants
-        @job_constants ||= config.values.compact.flat_map(&:keys).uniq
+        @job_constants ||= config.values.compact.flat_map(&:keys).to_set.to_a
       end
 
       def with_database?

--- a/lib/ci_helper/commands/check_sidekiq_scheduler_config.rb
+++ b/lib/ci_helper/commands/check_sidekiq_scheduler_config.rb
@@ -29,7 +29,7 @@ module CIHelper
       end
 
       def job_constants
-        @job_constants ||= config.values.compact.flat_map(&:keys).to_set.to_a
+        @job_constants ||= config.values.compact.flat_map(&:keys).uniq
       end
 
       def with_database?

--- a/lib/ci_helper/commands/check_spec_suffixes.rb
+++ b/lib/ci_helper/commands/check_spec_suffixes.rb
@@ -4,7 +4,7 @@ module CIHelper
   module Commands
     class CheckSpecSuffixes < BaseCommand
       def call
-        paths = target_paths.reject { |path| path.end_with?("_spec.rb") }
+        paths = target_paths.grep_v(/_spec\.rb\z/)
         fail!("Detected specs without _spec suffix: #{paths.join(" ")}") if paths.any?
         0
       end
@@ -16,16 +16,13 @@ module CIHelper
       end
 
       def spec_paths
-        base_paths.select do |path|
-          next if path.start_with?("spec/support")
-          next if path.start_with?("spec/factories")
-          next if path.end_with?("context.rb")
-          true
-        end
+        base_paths
+          .grep_v(%r{\A(?:spec/support|spec/factories)})
+          .grep_v(/context\.rb\z/)
       end
 
       def base_paths
-        Dir["spec/*/**/*.rb"]
+        path.glob("spec/*/**/*.rb").map { |file| file.relative_path_from(path).to_s }
       end
 
       def extra_paths

--- a/lib/ci_helper/commands/run_specs.rb
+++ b/lib/ci_helper/commands/run_specs.rb
@@ -33,7 +33,7 @@ module CIHelper
 
       def job_files
         heavy_files, std_files = all_spec_files.partition { |f| heavy?(relative(f)) }
-        sorted_std = std_files.map { |f| [f.size, relative(f)] }.sort.map(&:last)
+        sorted_std = std_files.sort_by(&:size).map { |f| relative(f) }
         distribute(sorted_std + heavy_files)
       end
 
@@ -55,14 +55,15 @@ module CIHelper
           rescue Error => error
             fail!("RSpec dry-run failed:\n#{error.output}")
           end
-          JSON.parse(File.read(output_file)).fetch("examples").map { |e| e.fetch("id") }
+          JSON.parse(File.read(output_file)).fetch("examples").filter_map { |e| e["id"] }
         end
       end
 
       def distribute(items)
-        items.reverse.select.with_index do |_item, index|
-          (index % job_count) == (job_index - 1)
-        end
+        reversed = items.reverse
+        selected_indices =
+          (job_index.pred..).step(job_count).take_while { |index| index < reversed.length }
+        selected_indices.map { |index| reversed[index] }
       end
 
       def heavy?(relative_path)

--- a/lib/ci_helper/commands/run_specs.rb
+++ b/lib/ci_helper/commands/run_specs.rb
@@ -33,7 +33,7 @@ module CIHelper
 
       def job_files
         heavy_files, std_files = all_spec_files.partition { |f| heavy?(relative(f)) }
-        sorted_std = std_files.sort_by(&:size).map { |f| relative(f) }
+        sorted_std = std_files.sort_by { |f| [f.size, relative(f)] }.map { |f| relative(f) }
         distribute(sorted_std + heavy_files)
       end
 
@@ -55,7 +55,7 @@ module CIHelper
           rescue Error => error
             fail!("RSpec dry-run failed:\n#{error.output}")
           end
-          JSON.parse(File.read(output_file)).fetch("examples").filter_map { |e| e["id"] }
+          JSON.parse(File.read(output_file)).fetch("examples").map { |e| e.fetch("id") }
         end
       end
 

--- a/lib/tasks/sequel_management.rake
+++ b/lib/tasks/sequel_management.rake
@@ -64,7 +64,7 @@ class SequelManagement
         migration_files, error, status = Open3.capture3(git_command)
         abort "Can't get list of migration files:\n#{error}" unless status.success?
 
-        original_migrations = migration_files.split.filter_map { |path| File.basename(path) }
+        original_migrations = migration_files.split.map { |path| File.basename(path) }
         migrations_to_rollback = (ch_migrator.applied_migrations - original_migrations).sort.reverse
 
         next if migrations_to_rollback.empty?

--- a/lib/tasks/sequel_management.rake
+++ b/lib/tasks/sequel_management.rake
@@ -64,7 +64,7 @@ class SequelManagement
         migration_files, error, status = Open3.capture3(git_command)
         abort "Can't get list of migration files:\n#{error}" unless status.success?
 
-        original_migrations = migration_files.split.map { |path| File.basename(path) }
+        original_migrations = migration_files.split.filter_map { |path| File.basename(path) }
         migrations_to_rollback = (ch_migrator.applied_migrations - original_migrations).sort.reverse
 
         next if migrations_to_rollback.empty?
@@ -103,7 +103,7 @@ class SequelManagement
       if error.message.include?("does not exist in the filesystem")
         logger.info error.message
       else
-        raise error
+        raise
       end
     end
   end
@@ -115,7 +115,7 @@ class SequelManagement
       if error.message.include?("does not exist in the filesystem")
         logger.info error.message
       else
-        raise error
+        raise
       end
     end
   end

--- a/spec/ci_helper/commands/bundler_audit_spec.rb
+++ b/spec/ci_helper/commands/bundler_audit_spec.rb
@@ -26,7 +26,7 @@ describe CIHelper::Commands::BundlerAudit do
   end
 
   context "with ignored advisories" do
-    let(:options) { Hash[ignored_advisories: "kek,pek"] }
+    let(:options) { { ignored_advisories: "kek,pek" } }
 
     let(:expected_command) { "bundle exec bundler-audit check --update --ignore kek pek" }
 
@@ -38,7 +38,7 @@ describe CIHelper::Commands::BundlerAudit do
   end
 
   context "with empty ignored advisories" do
-    let(:options) { Hash[ignored_advisories: ""] }
+    let(:options) { { ignored_advisories: "" } }
 
     it "executes command without ignore flag" do
       expect(command).to eq(0)

--- a/spec/ci_helper/commands/check_coverage_spec.rb
+++ b/spec/ci_helper/commands/check_coverage_spec.rb
@@ -11,7 +11,7 @@ describe CIHelper::Commands::CheckCoverage do
   before { allow(Pathname).to receive(:pwd).and_return(mocked_pathname) }
 
   let(:collate_args) { [] }
-  let(:options) { Hash[split_resultset: "true"] }
+  let(:options) { { split_resultset: "true" } }
 
   let(:mocked_pathname) do
     instance_double(Pathname).tap do |pathname|
@@ -42,7 +42,7 @@ describe CIHelper::Commands::CheckCoverage do
     subject(:command) { instance.call }
 
     let(:instance) { described_class.new(**options) }
-    let(:options) { Hash[setup_file_path: "relative/path/to/spec_helper"] }
+    let(:options) { { setup_file_path: "relative/path/to/spec_helper" } }
 
     it "requires this file" do
       expect(instance).to receive(:require).with(pathname_for_join)

--- a/spec/ci_helper/commands/check_db_development_spec.rb
+++ b/spec/ci_helper/commands/check_db_development_spec.rb
@@ -23,7 +23,7 @@ describe CIHelper::Commands::CheckDBDevelopment do
   end
 
   context "when with_clickhouse options" do
-    let(:options) { Hash[with_clickhouse: "true"] }
+    let(:options) { { with_clickhouse: "true" } }
 
     let(:expected_commands) do
       [

--- a/spec/ci_helper/commands/check_db_rollback_spec.rb
+++ b/spec/ci_helper/commands/check_db_rollback_spec.rb
@@ -24,7 +24,7 @@ describe CIHelper::Commands::CheckDBRollback do
   end
 
   context "when with_clickhouse options" do
-    let(:options) { Hash[with_clickhouse: "true"] }
+    let(:options) { { with_clickhouse: "true" } }
 
     let(:expected_commands) do
       [

--- a/spec/ci_helper/commands/check_sidekiq_scheduler_config_spec.rb
+++ b/spec/ci_helper/commands/check_sidekiq_scheduler_config_spec.rb
@@ -28,7 +28,7 @@ describe CIHelper::Commands::CheckSidekiqSchedulerConfig do
     YAML
   end
 
-  let(:options) { Hash[config_path: config.path] }
+  let(:options) { { config_path: config.path } }
 
   let(:expected_commands) do
     [
@@ -42,7 +42,7 @@ describe CIHelper::Commands::CheckSidekiqSchedulerConfig do
   end
 
   context "with database" do
-    let(:options) { Hash[config_path: config.path, with_database: "true"] }
+    let(:options) { { config_path: config.path, with_database: "true" } }
 
     let(:expected_commands) do
       [

--- a/spec/ci_helper/commands/check_spec_suffixes_spec.rb
+++ b/spec/ci_helper/commands/check_spec_suffixes_spec.rb
@@ -13,7 +13,7 @@ describe CIHelper::Commands::CheckSpecSuffixes do
   specify { expect(command).to eq(0) }
 
   context "with extra paths" do
-    let(:options) { Hash[extra_paths: "spec/*.rb"] }
+    let(:options) { { extra_paths: "spec/*.rb" } }
 
     specify do
       expect { command }.to raise_error(/specs without _spec suffix/)
@@ -42,7 +42,7 @@ describe CIHelper::Commands::CheckSpecSuffixes do
     end
 
     context "with ignored paths" do
-      let(:options) { Hash[ignored_paths: "spec/ci_helper/*.rb"] }
+      let(:options) { { ignored_paths: "spec/ci_helper/*.rb" } }
 
       specify { expect(command).to eq(0) }
     end

--- a/spec/ci_helper/commands/run_specs_spec.rb
+++ b/spec/ci_helper/commands/run_specs_spec.rb
@@ -9,7 +9,7 @@ describe CIHelper::Commands::RunSpecs do
 
   before { allow(Pathname).to receive(:pwd).and_return(mocked_pathname) }
 
-  let(:options) { Hash[split_resultset: "true", with_database: "true", with_clickhouse: "true"] }
+  let(:options) { { split_resultset: "true", with_database: "true", with_clickhouse: "true" } }
 
   let(:mocked_pathname) do
     instance_double(Pathname).tap do |pathname|


### PR DESCRIPTION
Hi @tycooon! 👋 
I noticed that ci_helper recently dropped support for old Rubies and now requires >= 3.2.0. I decided to do a quick pass over the commands to apply modern Ruby 3.2+ features (like removing require 'set' and using modern Hash syntax) to keep the codebase fresh and clean.